### PR TITLE
Fix: Remove reference to missing document

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Lista de Documentos (podría venir de un JSON o API en el futuro) ---
     const documents = [
         { name: "Ley Orgánica Ministerio Público", path: "docs/ley_organica_ministerio_publico.html" },
-        { name: "Código Penal (Extracto)", path: "docs/codigo_penal.html" },
         // Agrega más documentos aquí
     ];
 


### PR DESCRIPTION
Removes "Código Penal (Extracto)" from the document list in `app.js`. This document file (`docs/codigo_penal.html`) was not present in the repository, leading to an error when you attempted to load it.

This change ensures that only available documents are listed, preventing errors you might encounter and improving the application's reliability.